### PR TITLE
Use wmctrl (if installed) to raise and focus window.

### DIFF
--- a/README
+++ b/README
@@ -30,3 +30,8 @@ Here's his original readme:
     the main menu entries... just type the extra 's' (that is, type
     'skypes' instead of just 'skype'), and that should bring up
     skype-single-instance.
+
+Later additions:
+
+- If you have 'wmctrl' installed, the script will aldo raise and focus
+  the skype window.

--- a/skype-single-instance
+++ b/skype-single-instance
@@ -1,7 +1,10 @@
 #!/usr/bin/env python
 import dbus
+import subprocess
 import sys
-import os
+import time
+
+MAX_SECONDS_WAITING_TO_APPEAR = 5
 
 try:
     # Try and set skype window to normal
@@ -14,8 +17,15 @@ try:
     out_connection.Invoke('FOCUS')
 
     # 'FOCUS' does not reliably raise the window or give it keyboard focus :-(
-    if os.system('which wmctrl') == 0:
-        os.system(u'wmctrl -a Skype\N{TRADE MARK SIGN}'.encode('utf-8'))
+    if subprocess.call(['which', 'wmctrl'], stdout=subprocess.PIPE) == 0:
+        skype_title_pattern = u'Skype\N{TRADE MARK SIGN}'.encode('utf-8')
+        t0 = time.time()
+        while (skype_title_pattern not in
+               subprocess.check_output(['wmctrl', '-l'])
+               and
+               time.time() < t0 + MAX_SECONDS_WAITING_TO_APPEAR):
+            time.sleep(0.25)
+        subprocess.check_call(['wmctrl', '-a', skype_title_pattern])
     else:
         # Fallback: This only partially raises and doesn't seem to focus.
         # It does draw attention to where the covered window is.
@@ -23,5 +33,5 @@ try:
         out_connection.Invoke('SET WINDOWSTATE NORMAL')
 
 except:
-    os.system('skype')
+    subprocess.call(['skype'])
     sys.exit()

--- a/skype-single-instance
+++ b/skype-single-instance
@@ -15,7 +15,7 @@ try:
 
     # 'FOCUS' does not reliably raise the window or give it keyboard focus :-(
     if os.system('which wmctrl') == 0:
-        os.system(u'wmctrl -R Skype\N{TRADE MARK SIGN}'.encode('utf-8'))
+        os.system(u'wmctrl -a Skype\N{TRADE MARK SIGN}'.encode('utf-8'))
     else:
         # Fallback: This only partially raises and doesn't seem to focus.
         # It does draw attention to where the covered window is.

--- a/skype-single-instance
+++ b/skype-single-instance
@@ -12,6 +12,16 @@ try:
     #out_connection.Invoke('SET WINDOWSTATE MAXIMIZED')
     out_connection.Invoke('SET WINDOWSTATE NORMAL')
     out_connection.Invoke('FOCUS')
+
+    # 'FOCUS' does not reliably raise the window or give it keyboard focus :-(
+    if os.system('which wmctrl') == 0:
+        os.system(u'wmctrl -R Skype\N{TRADE MARK SIGN}'.encode('utf-8'))
+    else:
+        # Fallback: This only partially raises and doesn't seem to focus.
+        # It does draw attention to where the covered window is.
+        out_connection.Invoke('SET WINDOWSTATE HIDDEN')
+        out_connection.Invoke('SET WINDOWSTATE NORMAL')
+
 except:
-    os.system("skype")
+    os.system('skype')
     sys.exit()


### PR DESCRIPTION
The code already tells skype to 'FOCUS' but that doesn't work, at least for me.
(I'm on Fedora 23 with Cinnamon desktop.)
`wmctrl` works perfectly, so added code to run it and text to README to install it.

I also tried telling skype to close then restore the window — this did raise it, but kept it below the currently focused one. And it didn't seem to focus it all all.
Adding this as fallback when you don't have `wmctrl` installed.
